### PR TITLE
Substitute srcObject for URL.createObjectURL()

### DIFF
--- a/test.js
+++ b/test.js
@@ -103,7 +103,7 @@ var Camera = (function () {
                 _this._sec_per_frame = 1 / _this._fps;
                 _this._first_timestamp = _this._prev_frame_index = -1;
                 _this._video = document.createElement('video');
-                _this._video.src = URL.createObjectURL(strm);
+                _this._video.srcObject = strm;
                 _this._video.play();
                 _this._video.addEventListener('loadedmetadata', function (e) {
                     var w = _this._width = _this._video.videoWidth;


### PR DESCRIPTION
`createObjectURL(MediaStream)` is deprecated

- https://www.w3.org/Bugs/Public/show_bug.cgi?id=23091
- https://bugs.chromium.org/p/chromium/issues/detail?id=591719
- https://github.com/w3c/mediacapture-main/issues/404
- https://bugzilla.mozilla.org/show_bug.cgi?id=1334564